### PR TITLE
Fix create function in cases where window.ClassicEditor is set.

### DIFF
--- a/h5p-ckeditor.js
+++ b/h5p-ckeditor.js
@@ -115,7 +115,10 @@ H5P.CKEditor = (function (EventDispatcher, $) {
     };
 
     self.create = function () {
-      if (!window.ClassicEditor && !H5P.CKEditor.load) {
+      if (window.ClassicEditor) {
+        initCKEditor();
+      }
+      else if (!H5P.CKEditor.load) {
         H5P.CKEditor.load = new Promise((resolve, reject) => {
           // Load the CKEditor script if it hasn't been loaded yet
           const script = document.createElement('script');


### PR DESCRIPTION
When merged in, will fix the `create` function in cases where `window.ClassicEditor` is set.

Currently, the `create` function fails if `window.ClassicEditor` is set. The state will be `!== CREATED` and `H5P.CKEditor.load` will be called, but it's `undefined`. If `window.ClassicEditor` is set, `initCKEditor` should instead be called immediately.